### PR TITLE
Honor FG & BG Selections

### DIFF
--- a/SLMenu/SLMenu.MenuItem.psm1
+++ b/SLMenu/SLMenu.MenuItem.psm1
@@ -113,11 +113,15 @@ function New-SLMenuItem {
         [int[]]$KeyNums = @(),
 
         [parameter(ParameterSetName='MenuItem')]
+        [parameter(ParameterSetName='MenuItem-styles')]
         [string]$Message = '',
         [parameter(ParameterSetName='MenuItem')]
-        [string]$ForegroundColor = $Host.UI.RawUI.ForegroundColor.ToString(),
+         [string]$ForegroundColor = $Host.UI.RawUI.ForegroundColor.ToString(),
         [parameter(ParameterSetName='MenuItem')]
         [string]$BackgroundColor = $Host.UI.RawUI.BackgroundColor.ToString(),
+
+        [parameter(ParameterSetName='MenuItem-styles')]
+        $Style = @{},
 
         [parameter(ParameterSetName='Separator')]
         [switch]$Separator,
@@ -134,11 +138,31 @@ function New-SLMenuItem {
         ExtraKeys = $ExtraKeys
         KeyNums = $KeyNums
         Message = $Message
-        ForegroundColor = $ForegroundColor
-        BackgroundColor = $BackgroundColor
+        Style = @{}
         IsSeparator = [bool]($PsCmdlet.ParameterSetName -ieq 'Separator' -and $Separator)
         IsComment = [bool]($PsCmdlet.ParameterSetName -ieq 'Comment' -and $Comment)
     }
+    If ($PSCmdlet.ParameterSetName -eq "MenuItem-styles") {
+        $MenuItem.Style = @{
+            MessageForegroundColor = $Host.UI.RawUI.ForegroundColor.ToString()
+            MessageBackgroundColor = $Host.UI.RawUI.BackgroundColor.ToString()
+            ItemForegroundColor = $Host.UI.RawUI.ForegroundColor.ToString()
+            ItemBackgroundColor = $Host.UI.RawUI.BackgroundColor.ToString()    
+        }
+        ForEach ($I in $Style.Keys) {
+            Write-Host $I
+            $MenuItem.Style[$I] = $Style[$I]
+            
+        }
+    } Else {
+        $MenuItem.Style = @{
+            MessageForegroundColor = $ForegroundColor
+            MessageBackgroundColor = $BackgroundColor
+            ItemForegroundColor = $Host.UI.RawUI.ForegroundColor.ToString()
+            ItemBackgroundColor = $Host.UI.RawUI.BackgroundColor.ToString()    
+        }
+    }
+    
     # Make sure Key and Is<x> match
     if ($Key -ieq ' ') { $MenuItem.IsComment = $true }
     elseif ($Key -ieq '-') { $MenuItem.IsSeparator = $true }

--- a/SLMenu/SLMenu.ShowMenu.psm1
+++ b/SLMenu/SLMenu.ShowMenu.psm1
@@ -344,12 +344,12 @@ function DrawMenuBody {
 
         # if this is the selected menu item, then swap background and foreground colour
         if ($MenuPosition -eq $MenuItem.Number) {
-            $fg = $Host.UI.RawUI.BackgroundColor
-            $bg = $Host.UI.RawUI.ForegroundColor
+            $fg = $MenuItem.BackgroundColor
+            $bg = $MenuItem.ForegroundColor
         }
         else {
-            $fg = $Host.UI.RawUI.ForegroundColor
-            $bg = $Host.UI.RawUI.BackgroundColor
+            $fg = $MenuItem.ForegroundColor
+            $bg = $MenuItem.BackgroundColor
         }
         if ($MenuItem.IsComment) {
             Write-Host $MenuItem.Name -NoNewLine

--- a/SLMenu/SLMenu.ShowMenu.psm1
+++ b/SLMenu/SLMenu.ShowMenu.psm1
@@ -344,12 +344,12 @@ function DrawMenuBody {
 
         # if this is the selected menu item, then swap background and foreground colour
         if ($MenuPosition -eq $MenuItem.Number) {
-            $fg = $MenuItem.BackgroundColor
-            $bg = $MenuItem.ForegroundColor
+            $fg = $MenuItem.Style.ItemBackgroundColor
+            $bg = $MenuItem.Style.ItemForegroundColor
         }
         else {
-            $fg = $MenuItem.ForegroundColor
-            $bg = $MenuItem.BackgroundColor
+            $fg = $MenuItem.Style.ItemForegroundColor
+            $bg = $MenuItem.Style.ItemBackgroundColor
         }
         if ($MenuItem.IsComment) {
             Write-Host $MenuItem.Name -NoNewLine
@@ -363,7 +363,7 @@ function DrawMenuBody {
             Write-Host " $($MenuItem.Key): $($MenuItem.Name)" -NoNewLine -ForegroundColor $fg -BackgroundColor $bg
             if ($MenuItem.Message -ne '') {
                 Write-Host ' ' -NoNewLine
-                Write-Host $MenuItem.Message -ForegroundColor $MenuItem.ForegroundColor -BackgroundColor $MenuItem.BackgroundColor -NoNewLine
+                Write-Host $MenuItem.Message -ForegroundColor $MenuItem.Style.MessageForegroundColor -BackgroundColor $MenuItem.Style.MessageBackgroundColor -NoNewLine
             }
             Clear-SLConsoleLine
         }


### PR DESCRIPTION
Currently Background and Foreground selections on a <menuitem>.Add are not actually honored. This change will honor them if they are actually specified. Otherwise, the default values of .Add fall back to session/system defaults automatically